### PR TITLE
Add fuzzing harness and safeguards against large allocations; #4

### DIFF
--- a/qoi_fuzz.c
+++ b/qoi_fuzz.c
@@ -1,0 +1,18 @@
+#define QOI_IMPLEMENTATION
+#define MAX_ALLOC (1 * 1024 * 1024)
+#include "qoi.h"
+#include <stddef.h>
+#include <stdint.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  int w, h;
+  if (size < 4) {
+    return 0;
+  }
+
+  void* decoded = qoi_decode((void*)(data + 4), (int)(size - 4), &w, &h, *((int *)data));
+  if (decoded != NULL) {
+	  QOI_FREE(decoded);
+  }
+  return 0;
+}


### PR DESCRIPTION
This adds the fuzzing harness mentioned in issue #4 and adds a new preprocessor macro for specifying the max allocation size.

To compile and run:

```
$ clang -fsanitize=address,fuzzer -g -O0 qoi_fuzz.c && ./a.out
```