### PR TITLE
Close file on allocation failure in `qoi_read()`

### DIFF
--- a/qoi.h
+++ b/qoi.h
@@ -514,6 +514,7 @@ void *qoi_read(const char *filename, int *out_w, int *out_h, int channels) {
 
 	void *data = QOI_MALLOC(size);
 	if (!data) {
+		fclose(f);
 		return NULL;
 	}
 


### PR DESCRIPTION
Ensure that the file is closed before returning from `qoi_read()` in the case of an allocation failure.