### PR TITLE
change encoding format, ~7% smaller files on kodim test suite

### DIFF
--- a/qoi.h
+++ b/qoi.h
@@ -284,7 +284,7 @@ void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels);
 #define QOI_MASK_3  0xe0 // 11100000
 #define QOI_MASK_4  0xf0 // 11110000
 
-#define QOI_COLOR_HASH(C) (C.rgba.r ^ C.rgba.g ^ C.rgba.b ^ C.rgba.a)
+#define QOI_COLOR_HASH(C) qoi_color_hash(C)
 #define QOI_MAGIC \
 	(((unsigned int)'q') << 24 | ((unsigned int)'o') << 16 | \
 	 ((unsigned int)'i') <<  8 | ((unsigned int)'f'))
@@ -297,6 +297,17 @@ typedef union {
 	struct { unsigned char r, g, b, a; } rgba;
 	unsigned int v;
 } qoi_rgba_t;
+
+unsigned int qoi_color_hash(qoi_rgba_t px)
+{
+	unsigned int h = px.rgba.b | (px.rgba.g << 8) | (px.rgba.r << 16);
+	h ^= h >> 15;
+	h *= 0xdb91908du;
+	h ^= h >> 16;
+	h *= 0x6be5be6fu;
+	h ^= h >> 17;
+	return h ^ px.rgba.a;
+}
 
 void qoi_write_32(unsigned char *bytes, int *p, unsigned int v) {
 	bytes[(*p)++] = (0xff000000 & v) >> 24;

--- a/qoi.h
+++ b/qoi.h
@@ -103,9 +103,9 @@ QOI_INDEX {
 
 QOI_DIFF_8 {
 	u8 tag  :  2;   // b01
-	u8 dr   :  2;   // 2-bit   red channel difference: -1..2
-	u8 dg   :  2;   // 2-bit green channel difference: -1..2
-	u8 db   :  2;   // 2-bit  blue channel difference: -1..2
+	u8 dr   :  2;   // 2-bit   red channel difference: -2..1
+	u8 dg   :  2;   // 2-bit green channel difference: -2..1
+	u8 db   :  2;   // 2-bit  blue channel difference: -2..1
 }
 
 QOI_DIFF_16 {


### PR DESCRIPTION
by changing the encoding a bit, I've managed to reduce qoi file sizes on the kodim testsuite
the new encoding operates in two modes, color (default) and alpha.
alpha mode is more suited for images with varying alpha channel, improving the compression ratio even more
improving the hashing function may improve the sizes even further, but I kept it as is to minimize performance impact
