### PR TITLE
add AUR package and create packages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ fits in about 300 lines of C.
 converts between png <> qoi
  - [qoibench.c](https://github.com/phoboslab/qoi/blob/master/qoibench.c)
 a simple wrapper to benchmark stbi, libpng and qoi
+
+## Packages
+
+[AUR](https://aur.archlinux.org/pkgbase/qoi-git/) - system-wide qoi.h, qoiconv and qoibench install as split packages.
+


### PR DESCRIPTION
I have created an AUR package for the library and the utilities.
It consists of a split-package with:
- `qoi-headers-git` - installs `qoi.h` into `/usr/include/qoi.h` so it is available to include system-wide
- `qoiconv-git` and `qoibench-git` - installs `qoiconv` and `qoibench` to `/usr/bin`

AUR includes a package for `stb` so that is marked as a build dependency for the base.
I use `sed` to replace the local include of `stb_image.h` and `stb_image_write.h` to a system include since the `stb` package makes them available under `/usr/include/stb/`

I plan to keep this decently updated, but the pace of development is quite high.