### PR TITLE
Optimize decoding run opcodes

### DIFF
--- a/qoibench.c
+++ b/qoibench.c
@@ -384,6 +384,9 @@ benchmark_result_t benchmark_image(const char *path, int runs) {
 	BENCHMARK_FN(runs, res.qoi.decode_time, {
 		qoi_desc desc;
 		void *dec_p = qoi_decode(encoded_qoi, encoded_qoi_size, &desc, 4);
+		if ((i == 0) && memcmp(dec_p, pixels, w*h*4)) {
+			ERROR("QOI encode/decode round trip was not lossless");
+		}
 		free(dec_p);
 	});
 


### PR DESCRIPTION
Narrowing the scope of the "int run" variable takes one of the branches
out of the inner loop for non-run opcodes. It also makes it easier for
the compiler to recognize and optimize a run-length decode as a classic
memset loop.

Also have qoibench.c ensure that encode-then-decode QOI is lossless,
which helps check that the qoi_decode changes are still correct.

Decode mpps speed-ups are flat for photographic images (kodak, textures,
wallpaper), but significant for others (misc 1.43x, screenshots 1.64x).
For photos, though, JPEG (or other lossy formats) are probably more
appropriate than lossless formats like PNG or QOI.

The screenshots set, in particular, has longer runs on average (see
https://github.com/nigeltao/qoi2-bikeshed/issues/14).

        decode ms   encode ms   decode mpps   encode mpps   size kb

images/kodak
qoi-before:   3.3         4.3        120.36         91.89       771
qoi-after:    3.4         4.3        114.43         92.14       771

images/misc
qoi-before:   2.9         3.0        304.08        293.35       400
qoi-after:    2.0         2.9        434.93        301.85       400

images/screenshots
qoi-before:  25.4        24.0        324.64        342.33      2582
qoi-after:   15.5        22.5        532.18        366.48      2582

images/textures
qoi-before:   0.8         1.0        156.67        127.27       184
qoi-after:    0.8         1.0        158.08        127.93       184

images/wallpaper
qoi-before:  68.1        78.1        137.56        119.95     10640
qoi-after:   68.5        77.5        136.90        120.86     10640