### PR TITLE
Add readme section for wrappers/bindings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ a simple wrapper to benchmark stbi, libpng and qoi
 - https://github.com/panzi/jsqoi (TypeScript)
 - https://github.com/pfusik/qoi-ci (Ć)
 
+## Bindings
+
+- https://github.com/cbaltzer/qoi-swift (Swift)
 
 ## Packages
 


### PR DESCRIPTION
Added a section for wrappers or other utilities using the standard implementation or connecting to higher level APIs. 

(aka shameful self plug for [qoi-swift](https://github.com/cbaltzer/qoi-swift), I'm sorry) 