### PR TITLE
Add link in readme to kodonnell/qoi (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ a simple wrapper to benchmark stbi, libpng and qoi
 - https://github.com/xfmoulet/qoi (Go)
 - https://github.com/panzi/jsqoi (TypeScript)
 - https://github.com/pfusik/qoi-ci (Ć)
+- https://github.com/kodonnell/qoi (Python)
 
 
 ## Packages


### PR DESCRIPTION
As per title.