### PR TITLE
Force rarer PNG encodings to be read by qoiconv as RGBA

### DIFF
--- a/qoiconv.c
+++ b/qoiconv.c
@@ -58,7 +58,17 @@ int main(int argc, char **argv) {
 	void *pixels = NULL;
 	int w, h, channels;
 	if (STR_ENDS_WITH(argv[1], ".png")) {
-		pixels = (void *)stbi_load(argv[1], &w, &h, &channels, 0);
+		if(!stbi_info(argv[1], &w, &h, &channels)) {
+			printf("Couldn't read header %s\n", argv[1]);
+			exit(1);
+		}
+		if(channels < 3) {// Force all odd encodings to be RGBA
+			channels = 4;
+			pixels = (void *)stbi_load(argv[1], &w, &h, NULL, 4);
+		}
+		else {
+			pixels = (void *)stbi_load(argv[1], &w, &h, &channels, 0);
+		}
 	}
 	else if (STR_ENDS_WITH(argv[1], ".qoi")) {
 		qoi_desc desc;


### PR DESCRIPTION
The following images from the test suite fail to be encoded with qoiconv because they are 1 or 2 channel PNG's:
```
./pngimg/bone_PNG30.png
./pngimg/brain_PNG13.png
./pngimg/cursor_PNG65.png
./pngimg/cursor_PNG68.png
./pngimg/milk_PNG12713.png
./pngimg/razor_blade_PNG17804.png
./pngimg/silver_PNG17125.png
./pngimg/snapchat_PNG35.png
./pngimg/thug_life_PNG15.png
./screenshot_game/Ballerburg.png
./screenshot_game/OXO_emulated_portion.png
./screenshot_game/Sega-Mega-Drive-regional-lockout-error.png
```
qoibench doesn't have this problem because they are converted to RGBA. This quick fix does the same. It may be possible to read odd encodings with no alpha as RGB instead, but it's safer not to as PNG has many ways of doing that. Forcing RGBA hopefully catches all (at least 8 bit) cases.