### PR TITLE
Add SerenityOS implementation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ implementations listed below.
 - https://github.com/saharNooby/qoi-java (Java)
 - https://github.com/Cr4xy/lua-qoi (Lua)
 - https://github.com/superzazu/SDL_QOI (C, SDL2 bindings)
+- https://github.com/SerenityOS/serenity (in system-wide [LibGfx](https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibGfx/QOILoader.h))
 
 
 ## Packages


### PR DESCRIPTION
With commit SerenityOS/serenity@0356ee9 , the Serenity Operating System supports QOI natively through its system-wide LibGfx. Thanks to the original implementor @linusg !