### PR TITLE
Add Raylib as QOI supporting software

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ implementations listed below.
 ## QOI Support in Other Software
 
 - [SerenityOS](https://github.com/SerenityOS/serenity) supports decoding QOI system wide through a custom [cpp implementation in LibGfx](https://github.com/SerenityOS/serenity/blob/master/Userland/Libraries/LibGfx/QOILoader.h)
+- [Raylib](https://github.com/raysan5/raylib) supports decoding and encoding QOI textures through its [rtextures module](https://github.com/raysan5/raylib/blob/master/src/rtextures.c)
 
 
 ## Packages


### PR DESCRIPTION
Creator _Ray_ had added **QOI** as a supported texture format quite early, though I requested it be optional by default once I saw the final specification was still WIP. Now its back to being enabled by default!