### PR TITLE
Move Qoix to the implementations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ implementations listed below.
 - https://github.com/Cr4xy/lua-qoi (Lua)
 - https://github.com/superzazu/SDL_QOI (C, SDL2 bindings)
 - https://github.com/saharNooby/qoi-java (Java)
+- https://github.com/rbino/qoix (Elixir)
 
 
 ## QOI Support in Other Software
@@ -80,6 +81,5 @@ These implementations are based on the pre-release version of QOI. Resulting fil
 - https://github.com/panzi/jsqoi (TypeScript)
 - https://github.com/0xd34df00d/hsqoi (Haskell)
 - https://github.com/NUlliiON/QoiSharp (C#)
-- https://github.com/rbino/qoix (Elixir)
 - https://github.com/elihwyma/Swift-QOI (Swift)
 


### PR DESCRIPTION
Qoix is now aligned with v1.0 spec, see https://github.com/rbino/qoix/pull/2/files