### PR TITLE
Makefile + proper packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,3 @@
-#-- LICENSE: The MIT License(MIT) 
-# Copyright(c) 2021 Dr Ashton Fagg <ashton@fagg.id.au>
-#
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation
-# files(the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and / or sell copies of the
-# Software, and to permit persons to whom the Software is furnished to
-# do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.  THE
-# SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
 CFLAGS=-O3 -march=native -mtune=native -Wall -Wextra -pedantic -Ithird_party
 CFLAGS_LIBPNG=`pkg-config --cflags libpng`
 LDFLAGS_LIBPNG=`pkg-config --libs libpng`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+#-- LICENSE: The MIT License(MIT) 
+# Copyright(c) 2021 Dr Ashton Fagg <ashton@fagg.id.au>
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files(the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and / or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to
+# do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.  THE
+# SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+CFLAGS=-O3 -march=native -mtune=native -Wall -Wextra -pedantic -Ithird_party
+CFLAGS_LIBPNG=`pkg-config --cflags libpng`
+LDFLAGS_LIBPNG=`pkg-config --libs libpng`
+INSTALL=`which install`
+RM=`which rm`
+
+qoibench:
+	$(CC) $(CFLAGS) $(CFLAGS_LIBPNG) $(LDFLAGS_LIBPNG) -o qoibench qoibench.c
+
+qoiconv:
+	$(CC) $(CFLAGS) $(CFLAGS_LIBPNG) $(LDFLAGS_LIBPNG) -o qoiconv qoiconv.c
+
+.PHONY: tools clean tools-install hdr-install\
+	tools-uninstall hdr-uninstall\
+	install uninstall
+
+tools: qoibench qoiconv
+tools-install: tools
+	$(INSTALL) -o root -g wheel -m 755 qoibench ${prefix}/bin/qoibench
+	$(INSTALL) -o root -g wheel -m 755 qoiconv ${prefix}/bin/qoiconv
+
+tools-uninstall:
+	$(RM) ${prefix}/bin/qoibench
+	$(RM) ${prefix}/bin/qoiconv
+
+hdr-install: qoi.h
+	$(INSTALL) -o root -g wheel -m 755 qoi.h ${prefix}/include/qoi.h
+
+hdr-uninstall:
+	$(RM) ${prefix}/include/qoi.h
+
+install: tools-install hdr-install
+uninstall: tools-uninstall hdr-uninstall
+
+clean:
+	rm -rf *.o qoiconv qoibench

--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ converts between png <> qoi
  - [qoibench.c](https://github.com/phoboslab/qoi/blob/master/qoibench.c)
 a simple wrapper to benchmark stbi, libpng and qoi
 
+## Compile & Install
+
+`make tools`
+`sudo make prefix=/usr install`
+
+This will compile `qoibench` and `qoiconv` and install them under `/usr/bin`. `qoi.h` will be installed to `/usr/include/qoi.h`.
+
+The Makefile assumes you have `libpng` installed on your system, and
+that `pkg-config` is able to provide the appropriate compiler and
+linker flags to enable its use.
+
+Adjust `prefix=/usr` to suit your preferences/system.
+
+To remove:
+
+`sudo make prefix=/usr uninstall`.
+
+This will remove everything. Note you need to use the same `prefix` setting as you installed with.
 
 ## Limitations
 

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,48 @@
+These files are sourced from:
+
+https://github.com/nothings/stb
+
+stb_image.h - v2.27
+stb_image_write.h - v1.16
+
+They are licensed under the following terms:
+
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------


### PR DESCRIPTION
I do not know whether this is of interest, but thought I would share it anyway.

1. Adds a `third_party` directory containing the appropriate headers from stb. Also adds an acknowledgement file (separate README.md) stating that they are licensed under different terms to the base QOI library (either public domain or MIT).
2. Defines a Makefile to make it easier to build and install the conversion and benchmark tooling.
3. Adds some basic instructions to README.md.

I can only test this on OpenBSD right now, however I did test it with GNU Make (as well as BSD Make) and it is working fine here. There is no reason that this should not work on Linux or Mac provided my memory serves correctly. I cannot test on Mac, but I can probably test on Linux at some point soon.

I will not be offended if you don't want this - I am doing this mainly to make it easier for myself as I am intending to package this for OpenBSD ports, and just thought I would share. :-)