### PR TITLE
rapid-qoi is now spec complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ implementations listed below.
 - https://github.com/Cr4xy/lua-qoi (Lua)
 - https://github.com/superzazu/SDL_QOI (C, SDL2 bindings)
 - https://github.com/saharNooby/qoi-java (Java)
+- https://github.com/zakarumych/rapid-qoi (Rust)
 
 
 ## QOI Support in Other Software
@@ -75,7 +76,6 @@ These implementations are based on the pre-release version of QOI. Resulting fil
 - https://github.com/MasterQ32/zig-qoi (Zig)
 - https://github.com/steven-joruk/qoi (Rust)
 - https://github.com/ChevyRay/qoi_rs (Rust)
-- https://github.com/zakarumych/rapid-qoi (Rust)
 - https://github.com/xfmoulet/qoi (Go)
 - https://github.com/panzi/jsqoi (TypeScript)
 - https://github.com/0xd34df00d/hsqoi (Haskell)


### PR DESCRIPTION
Starting with version 0.4.0 rapid-qoi implements finalized spec.