### PR TITLE
Mention qoic, an OCaml implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ implementations listed below.
 - https://github.com/DosWorld/pasqoi (Pascal)
 - https://github.com/elihwyma/Swift-QOI (Swift)
 - https://github.com/xfmoulet/qoi (Go)
+- https://erratique.ch/software/qoic (OCaml)
 
 
 ## QOI Support in Other Software


### PR DESCRIPTION
Here's an [OCaml](https://ocaml.org/) implementation. It round trips the specification test images.

Thanks for the work on the format, I like your style.  This is going to replace my `.tga` uses. 