### PR TITLE
Fix missing prototypes warning

### DIFF
--- a/qoi.h
+++ b/qoi.h
@@ -358,14 +358,14 @@ typedef union {
 
 static const unsigned char qoi_padding[8] = {0,0,0,0,0,0,0,1};
 
-void qoi_write_32(unsigned char *bytes, int *p, unsigned int v) {
+static void qoi_write_32(unsigned char *bytes, int *p, unsigned int v) {
 	bytes[(*p)++] = (0xff000000 & v) >> 24;
 	bytes[(*p)++] = (0x00ff0000 & v) >> 16;
 	bytes[(*p)++] = (0x0000ff00 & v) >> 8;
 	bytes[(*p)++] = (0x000000ff & v);
 }
 
-unsigned int qoi_read_32(const unsigned char *bytes, int *p) {
+static unsigned int qoi_read_32(const unsigned char *bytes, int *p) {
 	unsigned int a = bytes[(*p)++];
 	unsigned int b = bytes[(*p)++];
 	unsigned int c = bytes[(*p)++];


### PR DESCRIPTION
Functions qoi_write_32 and qoi_read_32 should either have a prototype
or be declared static. Do the latter, as theses functions are defined
in a header and should only exists in the same compilation unit as the
file including qoi.h and defining QOI_IMPLEMENTATION, ie not exported.

By adding the static keyword in the function declaration the following
command doesn't raise a missing-prototypes warning, anymore:
```
    cc -Wmissing-prototypes -DQOI_IMPLEMENTATION -c -o qoi.o -xc qoi.h
```