### PR TITLE
Add link to tev image viewer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ implementations listed below.
 - https://github.com/pfusik/qoi-ci/releases/tag/qoi-ci-1.1.0 - QOI Plugin installer for GIMP, Imagine, Paint.NET and XnView MP
 - https://github.com/iOrange/QoiFileTypeNet/releases/tag/v0.2 - QOI Plugin for Paint.NET
 - https://github.com/iOrange/QOIThumbnailProvider - Add thumbnails for QOI images in Windows Explorer
+- https://github.com/Tom94/tev - another native QOI viewer (allows pixel peeping and comparison with other image formats)
 
 
 ## Implementations & Bindings of QOI


### PR DESCRIPTION
Hi there, tev recently got support for loading QOI images.

tev's primary use is in graphics research for comparing images that are supposed to match, so it might come in handy to verify other qoi implementations. (Pixel peeping, error metrics, and the likes.)