### PR TITLE
Add link to qoiConverter X

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ implementations listed below.
 - https://github.com/iOrange/QoiFileTypeNet/releases/tag/v0.2 - QOI Plugin for Paint.NET
 - https://github.com/iOrange/QOIThumbnailProvider - Add thumbnails for QOI images in Windows Explorer
 - https://github.com/Tom94/tev - another native QOI viewer (allows pixel peeping and comparison with other image formats)
-- https://apps.apple.com/us/app/qoiconverterx/id1602159820 QOI <=> PNG converter available on the Mac App Store
+- https://apps.apple.com/br/app/qoiconverterx/id1602159820 QOI <=> PNG converter available on the Mac App Store
 
 
 ## Implementations & Bindings of QOI

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ implementations listed below.
 - https://github.com/iOrange/QoiFileTypeNet/releases/tag/v0.2 - QOI Plugin for Paint.NET
 - https://github.com/iOrange/QOIThumbnailProvider - Add thumbnails for QOI images in Windows Explorer
 - https://github.com/Tom94/tev - another native QOI viewer (allows pixel peeping and comparison with other image formats)
+- https://apps.apple.com/us/app/qoiconverterx/id1602159820 QOI <=> PNG converter available on the Mac App Store
 
 
 ## Implementations & Bindings of QOI


### PR DESCRIPTION
Added commercial software qoiConverterX. Available on Mac App Store.
https://apps.apple.com/us/app/qoiconverterx/id1602159820