### PR TITLE
Add `qoi` Rust crate reference (aldanor/qoi-rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ implementations listed below.
 - https://github.com/MasterQ32/zig-qoi (Zig)
 - https://github.com/rbino/qoix (Elixir)
 - https://github.com/NUlliiON/QoiSharp (C#)
+- https://github.com/aldanor/qoi-rust (Rust)
 - https://github.com/zakarumych/rapid-qoi (Rust)
 - https://github.com/takeyourhatoff/qoi (Go)
 - https://github.com/DosWorld/pasqoi (Pascal)
@@ -93,7 +94,6 @@ implementations listed below.
 
 These implementations are based on the pre-release version of QOI. Resulting files are not compatible with the current version.
 
-- https://github.com/steven-joruk/qoi (Rust)
 - https://github.com/ChevyRay/qoi_rs (Rust)
 - https://github.com/panzi/jsqoi (TypeScript)
 - https://github.com/0xd34df00d/hsqoi (Haskell)


### PR DESCRIPTION
Hi all, I finally got to finishing the main work on the Rust crate: https://github.com/aldanor/qoi-rust

@steven-joruk has kindly agreed to hand over the `qoi` crate name, so the Rust crate is available at https://crates.io/crates/qoi (and docs at https://docs.rs/qoi).

Here's preliminary benchmarks on the reference image suite:

```
Overall results: (2846 images, 4567.43 MB raw, 1320.95 MP):
---
             decode:Mp/s  encode:Mp/s  decode:MB/s  encode:MB/s
qoi.h              282.9        225.3        978.3        778.9
rapid-qoi          402.3        257.5       1390.9        890.2
qoi-rust           427.4        290.0       1477.7       1002.9
```

It could be made a bit faster, but that would require delving into unsafe Rust which people tend to dislike. With no-unsafe / no-simd / portable restrictions, I think it's pretty close to how fast it can get.

A few ideas were borrowed from @zakarumych's implementation (namely, hashing and run-length-1 encoding) and credited accordingly in the source code (however, some adjustments needed to be made to avoid bugs that were uncovered during testing).