### PR TITLE
qoi.h: Add SPDX license identifier

### DIFF
--- a/qoi.h
+++ b/qoi.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: MIT */
+/* SPDX-FileCopyrightText: 2021 Dominic Szablewski */
 /*
 
 QOI - The "Quite OK Image" format for fast, lossless image compression

--- a/qoibench.c
+++ b/qoibench.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2021 Dominic Szablewski
 /*
 
 Simple benchmark suite for png, stbi and qoi

--- a/qoiconv.c
+++ b/qoiconv.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2021 Dominic Szablewski
 /*
 
 Command line tool to convert between png <> qoi format

--- a/qoifuzz.c
+++ b/qoifuzz.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2021 Dominic Szablewski
 /*
 
 clang fuzzing harness for qoi_decode


### PR DESCRIPTION
SPDX license identifier are used in some big open-source project, it simplifies license parsing, see https://spdx.dev/ids/