### PR TITLE
Add qoixx in implementations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ implementations listed below.
 - https://github.com/MKCG/php-qoi (PHP)
 - https://github.com/LightHouseSoftware/qoiformats (D)
 - https://github.com/mhoward540/qoi-nim (Nim)
+- https://github.com/wx257osn2/qoixx (C++)
 
 
 ## QOI Support in Other Software


### PR DESCRIPTION
I implemented [`qoixx`](https://github.com/wx257osn2/qoixx), quite fast QOI implementation written in C++20. Especially the encoder of qoixx should be the fastest implementation yet because it uses SIMD instructions.

This PR adds `qoixx` in the implementations list.