### PR TITLE
QOI on an FPGA (Verilog)!

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ implementations listed below.
 - https://github.com/LightHouseSoftware/qoiformats (D)
 - https://github.com/mhoward540/qoi-nim (Nim)
 - https://github.com/wx257osn2/qoixx (C++)
+* https://github.com/amstan/qoi-fpga (FPGA: verilog)
 
 
 ## QOI Support in Other Software


### PR DESCRIPTION
Hey, when I saw how simple the QOI format is (single pass, barely any state), I was wondering how an FPGA implementation would fare (I've been doing FPGA image transporting recently, so it was fresh on my mind). I noticed nobody else has done it, so here's my implementation: https://github.com/amstan/qoi-fpga!

For now I have it implemented in a simulator ([verilator](https://www.veripool.org/verilator/)), with that I'm able to have drop in replacement functions (see the [shim file](https://github.com/amstan/qoi-fpga/blob/fpga/qoi_verilator_shim.c)) for `qoi_{encode,decode}`, which are linked back into qoiconv and the other tools for easier testing.

Hooking up to a real FPGA system (like a memory map and DMA) is still TODO, but should be very possible, I have all the "knobs" exposed.

Besides verilog, I also have plans to implement QOI using [LiteX](https://github.com/enjoy-digital/litex), which is another framework/python dialect used to develop fpga systems.

Once encoders/decoders become a thing in hardware, things could get **ridiculous**: HDMI screen capture cards, webcams providing lossless compressed QOI images. Devices like like [DisplayLink](https://en.wikipedia.org/wiki/DisplayLink) using QOI to compress the screen contents to save USB bandwidth (though, I think they already implement their own RLE format, but it would be cool if they used the now a standard QOI). Linux kernel V4L framework having an option for QOI encoded streams (as opposed to MJPG). I2C/[SPI displays](https://www.crystalfontz.com/products/arduino-lcd-displays.php#:~:text=Such%20a%20display%20takes%20230%2C400,or%203.5%20frames%20per%20second.) allowing QOI encoding for higher framerate.