### PR TITLE
Add musabkilic/qoi-decoder to implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ implementations listed below.
 - https://github.com/LightHouseSoftware/qoiformats (D)
 - https://github.com/mhoward540/qoi-nim (Nim)
 - https://github.com/wx257osn2/qoixx (C++)
-
+- https://github.com/musabkilic/qoi-decoder (Python)
 
 ## QOI Support in Other Software
 


### PR DESCRIPTION
Hi!
There are already Python projects mentioned in README, but one is implemented in Ć and the other is a wrapper. Since qoi-decoder is implemented in pure Python and (hopefully) easy to read, I thought it might have a place in README.