### PR TITLE
include py-qoi in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ implementations listed below.
 - https://github.com/mhoward540/qoi-nim (Nim)
 - https://github.com/wx257osn2/qoixx (C++)
 - https://github.com/musabkilic/qoi-decoder (Python)
+- https://github.com/mathpn/py-qoi (Python)
 
 ## QOI Support in Other Software
 


### PR DESCRIPTION
Just like [musabkilic](https://github.com/musabkilic), I also worked on a native python implementation of QOI this week. I also thought it could be of interest to others since both encoder and decoder are implemented and it might help python-people to understand the algorithm. 

Great work with QOI, really interesting project :smile:  