### PR TITLE
Add C streaming decoder to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ implementations listed below.
 - https://github.com/musabkilic/qoi-decoder (Python)
 - https://github.com/mathpn/py-qoi (Python)
 - https://github.com/JohannesFriedrich/qoi4R (R)
-
+- https://github.com/shraiwi/mini-qoi (C, streaming decoder)
 
 ## QOI Support in Other Software
 


### PR DESCRIPTION
Hi, I recently wrote a streaming QOI decoder that uses static memory allocation for embedded systems. I thought QOI had a lot of potential in the embedded space, so if you feel it's worth adding to the list of implementations then feel free to merge :)