### PR TITLE
Add 'dqoi' to the implementations list on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ either, as this "reference implementation" tries to be as easy to read as possib
 
 - https://github.com/pfusik/qoi-ci (Ć, transpiled to C, C++, C#, Java, JavaScript, Python and Swift)
 - https://github.com/kodonnell/qoi (Python)
-- https://github.com/JaffaKetchup/dqoi (Dart)
+- https://github.com/JaffaKetchup/dqoi (Dart, with Flutter support)
 - https://github.com/Cr4xy/lua-qoi (Lua)
 - https://github.com/superzazu/SDL_QOI (C, SDL2 bindings)
 - https://github.com/saharNooby/qoi-java (Java)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ either, as this "reference implementation" tries to be as easy to read as possib
 
 - https://github.com/pfusik/qoi-ci (Ć, transpiled to C, C++, C#, Java, JavaScript, Python and Swift)
 - https://github.com/kodonnell/qoi (Python)
+- https://github.com/JaffaKetchup/dqoi (Dart)
 - https://github.com/Cr4xy/lua-qoi (Lua)
 - https://github.com/superzazu/SDL_QOI (C, SDL2 bindings)
 - https://github.com/saharNooby/qoi-java (Java)


### PR DESCRIPTION
'[dqoi](https://github.com/JaffaKetchup/dqoi)' is my implementation of QOI for Dart and Flutter, based off the C code included here, and @LowLevelJavaScript's implementation.

I'm making this a draft for now, as it's still in alpha. However, it should be ready soon...