### PR TITLE
Add gamut D library

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ either, as this "reference implementation" tries to be as easy to read as possib
 - https://github.com/Fabien-Chouteau/qoi-spark (Ada/SPARK formally proven)
 - https://github.com/mzgreen/qoi-kotlin (Kotlin Multiplatform)
 - https://github.com/Aftersol/Simplified-QOI-Codec (C99, streaming encoder and decoder, freestanding)
+- https://github.com/AuburnSounds/gamut (D)
 
 ## QOI Support in Other Software
 


### PR DESCRIPTION
https://github.com/AuburnSounds/gamut

Announcement: https://forum.dlang.org/post/rnnvumdfuldmmruhiyjo@forum.dlang.org

Supports:

- QOI: 8-bit, RGB/RGBA
- QOIX: 8-bit, L/LA/RGB/RGBA. This is an evolving format, specific to Gamut, that embeds some developments in the QOI family of formats.