### PR TITLE
Add a singe byte streaming C99 QOI library and NodeJS bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ either, as this "reference implementation" tries to be as easy to read as possib
 - [AngusJohnson/TQoiImage](https://github.com/AngusJohnson/TQoiImage) - Delphi
 - [MarkJeronimus/qoi-java-spi](https://github.com/MarkJeronimus/qoi-java-spi) - Java SPI
 - [aumouvantsillage/qoi-racket](https://github.com/aumouvantsillage/qoi-racket) - Racket
+- [rubikscraft/qoi-stream](https://github.com/rubikscraft/qoi-stream) - C99, one byte at a time streaming encoder and decoder
+- [rubikscraft/qoi-img](https://github.com/rubikscraft/qoi-img) - NodeJS typescript, bindings to both [QOIxx](https://github.com/wx257osn2/qoixx) and [qoi-stream](https://github.com/rubikscraft/qoi-stream)
 
 ## QOI Support in Other Software
 


### PR DESCRIPTION
Hi there, I wrote these two libraries for QOI and thought I might as well add them to the rest. 
One is a streaming encoder and decoder in C that accepts a single byte at a time.
The other is a binding library to both QOIxx and my qoi-stream library. It just makes it easy to use faster C and C++ based libraries from NodeJS.
Hopefully they will be useful for some people.

