### PR TITLE
Add link to spwn-qoi

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ either, as this "reference implementation" tries to be as easy to read as possib
 - [MrNocole/ZTQOI](https://github.com/MrNocole/ZTQOI) - Objective-C
 - [bpanthi977/qoi](https://github.com/bpanthi977/qoi) - Common Lisp
 - [Floessie/pam2qoi](https://github.com/Floessie/pam2qoi) - C++
+- [SpeckyYT/spwn-qoi](https://github.com/SpeckyYT/spwn-qoi) - SPWN
 
 ## QOI Support in Other Software
 


### PR DESCRIPTION
`spwn-qoi` is a Quite OK Image Format decoder (and encoder in the future) for [SPWN](https://spu7nix.net/spwn/).