### PR TITLE
Support supplying additional LDFLAGS via environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 CC ?= gcc
 CFLAGS_BENCH ?= -std=gnu99 -O3
-LFLAGS_BENCH ?= -lpng
+LFLAGS_BENCH ?= -lpng $(LDFLAGS)
 CFLAGS_CONV ?= -std=c99 -O3
+LFLAGS_CONV ?= $(LDFLAGS)
 
 TARGET_BENCH ?= qoibench
 TARGET_CONV ?= qoiconv
@@ -14,7 +15,7 @@ $(TARGET_BENCH):$(TARGET_BENCH).c qoi.h
 
 conv: $(TARGET_CONV)
 $(TARGET_CONV):$(TARGET_CONV).c qoi.h
-	$(CC) $(CFLAGS_CONV) $(CFLAGS) $(TARGET_CONV).c -o $(TARGET_CONV)
+	$(CC) $(CFLAGS_CONV) $(CFLAGS) $(TARGET_CONV).c -o $(TARGET_CONV) $(LFLAGS_CONV)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Currently, a [patch](https://aur.archlinux.org/cgit/aur.git/tree/010-qoi-use-arch-flags.patch?h=qoi-git) with this change is applied when building the aur package. This breaks easily (and is broken now actually) with changes to the Makefile