### PR TITLE
Add function to detect magic header bytes

### DIFF
--- a/qoi.h
+++ b/qoi.h
@@ -278,6 +278,14 @@ The returned qoi data should be free()d after use. */
 void *qoi_encode(const void *data, const qoi_desc *desc, int *out_len);
 
 
+/* Check if a byte array contains the QOI magic header bytes.
+
+The function either returns 0 on failure (invalid parameters or magic
+header not detected) or 1 on success. */
+
+int qoi_detect_header_magic(const void *data, int size);
+
+
 /* Decode a QOI image from memory.
 
 The function either returns NULL on failure (invalid parameters or malloc
@@ -485,6 +493,19 @@ void *qoi_encode(const void *data, const qoi_desc *desc, int *out_len) {
 	return bytes;
 }
 
+int qoi_detect_header_magic(const void *data, int size) {
+	int p = 0;
+
+	if (
+		data == NULL ||
+		size < QOI_HEADER_SIZE + (int)sizeof(qoi_padding)
+	) {
+		return 0;
+	}
+
+	return qoi_read_32((const unsigned char *)data, &p) == QOI_MAGIC ? 1 : 0;
+}
+
 void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels) {
 	const unsigned char *bytes;
 	unsigned int header_magic;
@@ -580,7 +601,7 @@ void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels) {
 		pixels[px_pos + 0] = px.rgba.r;
 		pixels[px_pos + 1] = px.rgba.g;
 		pixels[px_pos + 2] = px.rgba.b;
-		
+
 		if (channels == 4) {
 			pixels[px_pos + 3] = px.rgba.a;
 		}


### PR DESCRIPTION
Hello, we're looking to add support for QOI and QOA in SFML 3.x (see https://github.com/SFML/SFML/issues/2969), and since we have a generic `sf::Image` abstraction that can be loaded from any path

```cpp
// from SFML/Image.hpp
[[nodiscard]] static std::optional<Image> loadFromFile(const std::filesystem::path& filename);
[[nodiscard]] static std::optional<Image> loadFromMemory(const void* data, std::size_t size);
[[nodiscard]] static std::optional<Image> loadFromStream(InputStream& stream);
```
    
it would be useful to be able to detect if the data we are reading is a valid QOI byte stream in order to internally decode it and store it in the right way.

For this purpose, I've added a `qoi_detect_header_magic` funcction to the `qoi.h` file, which simply tells the caller if the given byte array contains the QOI magic header bytes.

Such a function could then be used internally in SFML 3.x, to either end up calling `qoi_decode`, or falling back onto `stbi_load` for non-QOI formats.

Thank you for considering this contribution!

---

NOTE: I had considered making `qoi_detect_header_magic` share the same interface as `qoi_decode` and to use it internally in the latter function to avoid repetition, but ultimately decided against it as `qoi_detect_header_magic` does not need `desc` or `channels`, and it would have complicated the usage and interface of the simple header detection utility.