### PR TITLE
Require smaller encodings when multiple encodings are possible

### DIFF
--- a/qoi.h
+++ b/qoi.h
@@ -115,9 +115,6 @@ The possible chunks are:
 2-bit tag b00
 6-bit index into the color index array: 0..63
 
-A valid encoder must not issue 2 or more consecutive QOI_OP_INDEX chunks to the
-same index. QOI_OP_RUN should be used instead.
-
 
 .- QOI_OP_DIFF -----------.
 |         Byte[0]         |
@@ -178,6 +175,10 @@ The run-length is stored with a bias of -1. Note that the run-lengths 63 and 64
 (b111110 and b111111) are illegal as they are occupied by the QOI_OP_RGB and
 QOI_OP_RGBA tags.
 
+A valid encoder must not issue two or more consecutive QOI_OP_RUN chunks unless
+the run length in all chunks but the last is 62. Decoders are not required to
+check this constraint.
+
 
 .- QOI_OP_RGB ------------------------------------------.
 |         Byte[0]         | Byte[1] | Byte[2] | Byte[3] |
@@ -204,6 +205,19 @@ The alpha value remains unchanged from the previous pixel.
 8-bit green channel value
 8-bit  blue channel value
 8-bit alpha channel value
+
+A valid encoder must observe the chunk type priority order; if the next chunk to
+be emitted can be of more than one type, the chunk type must be the one of the
+higher priority. The chunk priorities, from highest to lowest, are:
+
+1. QOI_OP_RUN
+2. QOI_OP_INDEX
+3. QOI_OP_DIFF
+4. QOI_OP_LUMA
+5. QOI_OP_RGB
+6. QOI_OP_RGBA
+
+Decoders are not required to check this constraint.
 
 */
 


### PR DESCRIPTION
Before this commit, for some raw images, multiple qoi files can decode to them. This commit now requires encoders to choose chunks in a specific priority order -- an order that is already present in the code. One of the effects of this is that larger encodings are not valid when a smaller encoding is available. This commit also requires encoders to use maximal munch for RUN chunks.

As an example, consider the raw RGB image with pixel values

0x000000 0x000000

Before this commit, an encoding (minus the header and footer) of

b11000000 b11000000

(i.e. two runs of length 1) would be valid, even though the following encoding is shorter:

b11000001

(i.e. one run of length 2).

The priority order is RUN, INDEX, DIFF, LUMA, RGB, RGBA. This order does slightly more than just decreasing encoding size, however. For instance, for the raw RGB image

0x000000

this commit mandates the encoding use a RUN chunk rather than a DIFF chunk, even though they both have the same size (b11000000 vs. b01101010). The priority order in this commit allows encoders to choose a chunk type only once for each pixel and without needing any lookahead.

One way to specify the priority order would be to add to the comments on each chunk (other than RUN) a note about when the chunk must not be emitted. This is the way the comment on INDEX chunks was written before this commit. While doing so would create more eplicit rules, it would be longer and more complex than simply specifying a chunk priority order. As a result, this commit also removes that "must not issue" directive on INDEX chunks -- that rule is implicit in the chunk type priority order.