### PR TITLE
Add installation target and pkg-config module 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ stb_image.h
 stb_image_write.h
 qoibench
 qoiconv
+qoi.pc

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ TARGET_CONV ?= qoiconv
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 INCLUDEDIR ?= $(PREFIX)/include
+DATAROOTDIR ?= $(PREFIX)/share
 
 all: $(TARGET_BENCH) $(TARGET_CONV)
 
@@ -21,6 +22,11 @@ conv: $(TARGET_CONV)
 $(TARGET_CONV):$(TARGET_CONV).c qoi.h
 	$(CC) $(CFLAGS_CONV) $(CFLAGS) $(TARGET_CONV).c -o $(TARGET_CONV) $(LFLAGS_CONV)
 
+qoi.pc: qoi.pc.in
+	sed < qoi.pc.in > qoi.pc \
+		-e 's|@PREFIX@|$(PREFIX)|g' \
+		-e 's|@INCLUDEDIR@|$(INCLUDEDIR:$(PREFIX)%=$${prefix}%)|g'
+
 .PHONY: install
 install: install-tools install-header
 
@@ -30,8 +36,9 @@ install-tools: all
 	install -Dm 755 $(TARGET_BENCH) $(DESTDIR)$(BINDIR)/$(TARGET_BENCH)
 
 .PHONY: install-header
-install-header: qoi.h
+install-header: qoi.h qoi.pc
 	install -Dm 644 qoi.h $(DESTDIR)$(INCLUDEDIR)/qoi.h
+	install -Dm 644 qoi.pc $(DESTDIR)$(DATAROOTDIR)/pkgconfig/qoi.pc
 
 .PHONY: clean
 clean:

--- a/qoi.pc.in
+++ b/qoi.pc.in
@@ -1,0 +1,9 @@
+prefix=@PREFIX@
+includedir=@INCLUDEDIR@
+
+Name: qoi
+Description: The "Quite OK Image Format" for fast, lossless image compression
+Version: 0
+URL: https://qoiformat.org/
+License: MIT
+Cflags: -I${includedir}


### PR DESCRIPTION
This adds `install` target to the Makefile that installs the library header and built tools system wide. The installation directories follow [the GNU conventions](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) but can be customized.

The second commit adds generation of pkg-config module file. This makes it easier for build systems that utilize pkg-config (e.g., meson, cmake) to check whether the library exists and where its headers are installed.